### PR TITLE
[fix]Fixed incorrect variable name in setVariable second argument.

### DIFF
--- a/nr6_hal/HAL/HQSitRepB.sqf
+++ b/nr6_hal/HAL/HQSitRepB.sqf
@@ -575,7 +575,7 @@ while {true} do
 	_HQ setVariable ["RydHQ_GarrRange",RydHQB_GarrRange];
 		
 	if (isNil "RydHQB_NoCapt") then {RydHQB_NoCapt = []};
-	_HQ setVariable ["RydHQ_NoCapt",RydHQ_NoCapt];
+	_HQ setVariable ["RydHQ_NoCapt",RydHQB_NoCapt];
 	
 	if (isNil "RydHQB_AttInfDistance") then {RydHQB_AttInfDistance = 1};
 	_HQ setVariable ["RydHQ_AttInfDistance",RydHQB_AttInfDistance];

--- a/nr6_hal/HAL/HQSitRepC.sqf
+++ b/nr6_hal/HAL/HQSitRepC.sqf
@@ -574,7 +574,7 @@ while {true} do
 	_HQ setVariable ["RydHQ_GarrRange",RydHQC_GarrRange];
 
 	if (isNil "RydHQC_NoCapt") then {RydHQC_NoCapt = []};
-	_HQ setVariable ["RydHQ_NoCapt",RydHQ_NoCapt];
+	_HQ setVariable ["RydHQ_NoCapt",RydHQC_NoCapt];
 	
 	if (isNil "RydHQC_AttInfDistance") then {RydHQC_AttInfDistance = 1};
 	_HQ setVariable ["RydHQ_AttInfDistance",RydHQC_AttInfDistance];

--- a/nr6_hal/HAL/HQSitRepD.sqf
+++ b/nr6_hal/HAL/HQSitRepD.sqf
@@ -574,7 +574,7 @@ while {true} do
 	_HQ setVariable ["RydHQ_GarrRange",RydHQD_GarrRange];
 	
 	if (isNil "RydHQD_NoCapt") then {RydHQD_NoCapt = []};
-	_HQ setVariable ["RydHQ_NoCapt",RydHQ_NoCapt];
+	_HQ setVariable ["RydHQ_NoCapt",RydHQD_NoCapt];
 	
 	if (isNil "RydHQD_AttInfDistance") then {RydHQD_AttInfDistance = 1};
 	_HQ setVariable ["RydHQ_AttInfDistance",RydHQD_AttInfDistance];

--- a/nr6_hal/HAL/HQSitRepE.sqf
+++ b/nr6_hal/HAL/HQSitRepE.sqf
@@ -575,7 +575,7 @@ while {true} do
 	_HQ setVariable ["RydHQ_GarrRange",RydHQE_GarrRange];
 	
 	if (isNil "RydHQE_NoCapt") then {RydHQE_NoCapt = []};
-	_HQ setVariable ["RydHQ_NoCapt",RydHQ_NoCapt];
+	_HQ setVariable ["RydHQ_NoCapt",RydHQE_NoCapt];
 	
 	if (isNil "RydHQE_AttInfDistance") then {RydHQE_AttInfDistance = 1};
 	_HQ setVariable ["RydHQ_AttInfDistance",RydHQE_AttInfDistance];

--- a/nr6_hal/HAL/HQSitRepF.sqf
+++ b/nr6_hal/HAL/HQSitRepF.sqf
@@ -575,7 +575,7 @@ while {true} do
 	_HQ setVariable ["RydHQ_GarrRange",RydHQF_GarrRange];
 	
 	if (isNil "RydHQF_NoCapt") then {RydHQF_NoCapt = []};
-	_HQ setVariable ["RydHQ_NoCapt",RydHQ_NoCapt];
+	_HQ setVariable ["RydHQ_NoCapt",RydHQF_NoCapt];
 	
 	if (isNil "RydHQF_AttInfDistance") then {RydHQF_AttInfDistance = 1};
 	_HQ setVariable ["RydHQ_AttInfDistance",RydHQF_AttInfDistance];

--- a/nr6_hal/HAL/HQSitRepG.sqf
+++ b/nr6_hal/HAL/HQSitRepG.sqf
@@ -575,7 +575,7 @@ while {true} do
 	_HQ setVariable ["RydHQ_GarrRange",RydHQG_GarrRange];
 	
 	if (isNil "RydHQG_NoCapt") then {RydHQG_NoCapt = []};
-	_HQ setVariable ["RydHQ_NoCapt",RydHQ_NoCapt];
+	_HQ setVariable ["RydHQ_NoCapt",RydHQG_NoCapt];
 	
 	if (isNil "RydHQG_AttInfDistance") then {RydHQG_AttInfDistance = 1};
 	_HQ setVariable ["RydHQ_AttInfDistance",RydHQG_AttInfDistance];

--- a/nr6_hal/HAL/HQSitRepH.sqf
+++ b/nr6_hal/HAL/HQSitRepH.sqf
@@ -574,7 +574,7 @@ while {true} do
 	_HQ setVariable ["RydHQ_GarrRange",RydHQH_GarrRange];
 	
 	if (isNil "RydHQH_NoCapt") then {RydHQH_NoCapt = []};
-	_HQ setVariable ["RydHQ_NoCapt",RydHQ_NoCapt];
+	_HQ setVariable ["RydHQ_NoCapt",RydHQH_NoCapt];
 	
 	if (isNil "RydHQH_AttInfDistance") then {RydHQH_AttInfDistance = 1};
 	_HQ setVariable ["RydHQ_AttInfDistance",RydHQH_AttInfDistance];


### PR DESCRIPTION
# Why
In all HQSitRep{B,C,D,E,F,G}.sqf files, the second argument of _HQ setVariable ["RydHQ_NoCapt", arg2] is incorrect. It should correctly append a single letter alphabet to the end of HQ.

Incorrect: RydHQ_NoCapt
Correct: RydHQ{A,B,C,D,E,F,G}_NoCapt
If the CommanderModule assigned to LeaderA does not exist, the variable RydHQ_NoCapt remains unassigned. As a result, when the corresponding part is executed, RydHQ_NoCapt is treated as an undefined variable, causing an error. This needs to be fixed.

**Issue** #23
# What
Correct the argument name to the proper one.